### PR TITLE
add edn and clojure converters for ajax requests

### DIFF
--- a/src/jayq/core.cljs
+++ b/src/jayq/core.cljs
@@ -1,6 +1,7 @@
 (ns jayq.core
   (:refer-clojure :exclude [val empty remove find])
-  (:require [clojure.string :as string])
+  (:require [clojure.string :as string]
+            [cljs.reader :as reader])
   (:use [jayq.util :only [clj->js]]))
 
 (defn crate-meta [func]
@@ -194,6 +195,19 @@
     (.ajax js/jQuery url (clj->js settings)))
   ([settings]
     (.ajax js/jQuery (clj->js settings))))
+
+(defn ^:private mimetype-converter [s]
+  (reader/read-string (str s)))
+
+(.ajaxSetup js/jQuery
+ (clj->js
+  {:accepts {:edn "application/edn, text/edn"
+             :clojure "application/clojure, text/clojure"}
+   :contents {"clojure" #"edn|clojure"}
+   :converters
+   {"text edn" mimetype-converter
+    "text clojure" mimetype-converter}}))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Events


### PR DESCRIPTION
This allows the automatic reading of clojure or edn responses to clojure, this will check the supplied `dataType` option from `$.ajax` or try to guess it from the mime type of the response.  
It will work for application/edn, text/edn, application/clojure, text/clojure and both `dataType`s.
