### PR TITLE
add aliases to some missing dom manipulation/traversal methods

### DIFF
--- a/src/jayq/core.cljs
+++ b/src/jayq/core.cljs
@@ -112,6 +112,9 @@
   (let [cl (name cl)]
     (.hasClass $elem cl)))
 
+(defn is [$elem selector]
+  (.is $elem (->selector selector)))
+
 (defn after [$elem content]
   (.after $elem content))
 


### PR DESCRIPTION
Some trivial stuff, but still useful. I got bit a few times by using kw selectors on jq interop. 
I also took the liberty to change closest so that it can handle kw selectors.
