### PR TITLE
map serialisation to js fails when its of the persistent kind, since there is no strobj property on these.  

### DIFF
--- a/src/jayq/util.cljs
+++ b/src/jayq/util.cljs
@@ -23,7 +23,9 @@
   (cond
     (string? x) x
     (keyword? x) (name x)
-    (map? x) (.-strobj (reduce (fn [m [k v]]
-               (assoc m (clj->js k) (clj->js v))) {} x))
+    (map? x) (let [obj (js-obj)]
+               (doseq [[k v] x]
+                 (aset obj (clj->js k) (clj->js v)))
+               obj)
     (coll? x) (apply array (map clj->js x))
     :else x))


### PR DESCRIPTION
see:
https://groups.google.com/forum/?fromgroups=#!topic/clojure/Lasc8g89EGo
