### PR TITLE
Make log work like trace

### DIFF
--- a/src/jayq/util.cljs
+++ b/src/jayq/util.cljs
@@ -7,4 +7,5 @@
   (let [vs (if (string? v)
              (apply str v text)
              v)]
-    (. js/console (log vs))))
+    (. js/console (log vs))
+    v))


### PR DESCRIPTION
Log should return the passed value as is like clojure.tools.trace does. This allows use of log with arrow operators (-> and ->>).
