### PR TITLE
Fix 'no such namespace' warnings

### DIFF
--- a/src/jayq/core.cljs
+++ b/src/jayq/core.cljs
@@ -458,8 +458,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-(def $deferred $/Deferred)
-(def $when $/when)
+(def $deferred js/jQuery.Deferred)
+(def $when js/jQuery.when)
 
 (defn then
   ([deferred done-fn fail-fn]


### PR DESCRIPTION
Compilation gives the following warnings starting from ClojureScript version 0.0-2156:

```
WARNING: No such namespace: $ at line 461 src/jayq/core.cljs
WARNING: No such namespace: $ at line 462 src/jayq/core.cljs
```
