### PR TITLE
guard against nil contentType

### DIFF
--- a/src/jayq/core.cljs
+++ b/src/jayq/core.cljs
@@ -331,7 +331,8 @@
         (#(if ct
             (assoc % :contentType ct)
             %))
-        (#(if (clj-content-type? ct)
+        (#(if (and ct
+                   (clj-content-type? ct))
             (assoc % :data (pr-str data))
             %)))))
 


### PR DESCRIPTION
- As of ClojureScript
  0.0-2280 (https://github.com/clojure/clojurescript/commit/774d4588581f6d29a1b6b2555171d3f3d36c2c83),
  `re-find` will throw a TypeError for nil. If the caller of
  `jayq.core/preprocess-request` does not pass in a `contentType`, we
  should not be associng `:data` into the request.
