### PR TITLE
Corrected license declaration in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject jayq "2.5.4"
   :description "A ClojureScript wrapper for jQuery"
-  :license "Eclipse Public License 1.0"
+  :license {:name "Eclipse Public License 1.0"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/ibdknox/jayq")


### PR DESCRIPTION
The license declaration didn't follow the leiningen project.clj schema and was being ignored. I corrected that.